### PR TITLE
Adjust wake saving to avoid bounds error

### DIFF
--- a/src/analyses.jl
+++ b/src/analyses.jl
@@ -418,19 +418,19 @@ function unsteady_analysis!(system, surfaces, ref, fs, dt;
                 derivatives = last_step && derivatives)
         end
 
-        # save the surface shape, properties, and resulting shed wake
-        if it in save
-            surface_history[isave] = [copy(system.surfaces[isurf]) for isurf = 1:nsurf]
-            property_history[isave] = [copy(system.properties[isurf]) for isurf = 1:nsurf]
-            wake_history[isave] = [system.wakes[isurf][1:iwake[isurf] + 1, :] for isurf = 1:nsurf]
-            isave += 1
-        end
-
         # increment wake panel counter for each surface
         for isurf = 1:nsurf
             if iwake[isurf] < nwake[isurf]
                 iwake[isurf] += 1
             end
+        end
+
+        # save the surface shape, properties, and resulting shed wake
+        if it in save
+            surface_history[isave] = [copy(system.surfaces[isurf]) for isurf = 1:nsurf]
+            property_history[isave] = [copy(system.properties[isurf]) for isurf = 1:nsurf]
+            wake_history[isave] = [system.wakes[isurf][1:iwake[isurf], :] for isurf = 1:nsurf]
+            isave += 1
         end
 
     end


### PR DESCRIPTION
VortexLattice.jl looks great!

I was playing around with one of the unsteady examples and ran into a `BoundsError` while the code was saving the wake history. I think the problem was I was passing a value for `nwake` to `unsteady_analysis` that was less than the number of timesteps. I made a small change to `unsteady_analysis!` that seems to avoid the error. Here's the error:

```
julia> AcceleratingWing.doit()
ERROR: BoundsError: attempt to access 50×13 Matrix{WakePanel{Float64}} at index [1:51, 1:13]
Stacktrace:
  [1] throw_boundserror(A::Matrix{WakePanel{Float64}}, I::Tuple{UnitRange{Int64}, Base.Slice{Base.OneTo{Int64}}})
    @ Base ./abstractarray.jl:651
  [2] checkbounds
    @ ./abstractarray.jl:616 [inlined]
  [3] _getindex
    @ ./multidimensional.jl:831 [inlined]
  [4] getindex
    @ ./abstractarray.jl:1170 [inlined]
  [5] #341
    @ ./none:0 [inlined]
  [6] iterate
    @ ./generator.jl:47 [inlined]
  [7] collect(itr::Base.Generator{UnitRange{Int64}, VortexLattice.var"#341#349"{System{Float64}, Vector{Int64}}})
    @ Base ./array.jl:678
  [8] unsteady_analysis!(system::System{Float64}, surfaces::Vector{Matrix{SurfacePanel{Float64}}}, ref::Reference{Float64}, fs::Freestre
am{Float64}, dt::Vector{Float64}; symmetric::Bool, initial_circulation::Vector{Float64}, initial_wakes::Vector{Matrix{WakePanel{Float64}
}}, nwake::Int64, surface_id::UnitRange{Int64}, wake_finite_core::Bool, additional_velocity::Nothing, fcore::Function, save::UnitRange{I
nt64}, calculate_influence_matrix::Bool, near_field_analysis::Bool, derivatives::Bool)
    @ VortexLattice ~/projects/vlm_learning/dev/VortexLatticeLearning/dev/VortexLattice/src/analyses.jl:425
  [9] #unsteady_analysis#124
    @ ~/projects/vlm_learning/dev/VortexLatticeLearning/dev/VortexLattice/src/analyses.jl:272 [inlined]
 [10] doit()
    @ Main.AcceleratingWing ~/projects/vlm_learning/dev/VortexLatticeLearning/scripts/accelerating_wing.jl:60
 [11] top-level scope
    @ REPL[39]:1

julia>
```

And here's the script I was using that triggers the error:

```julia
module AcceleratingWing

using VortexLattice

function doit()
    AR = 4

    # non-dimensional time (t*Vinf/c)
    t = range(0.0, 10.0, step=1/16)

    # chord length
    c = 1

    # time step
    dt = [t[i+1]-t[i] for i = 1:length(t)-1]

    # span length
    b = AR*c

    # planform area
    S = b*c

    # geometry
    xle = [0.0, 0.0]
    yle = [-b/2, b/2]
    zle = [0.0, 0.0]
    chord = [c, c]
    theta = [0.0, 0.0]
    phi = [0.0, 0.0]
    fc = fill((xc) -> 0, 2) # camberline function for each section
    ns = 13
    nc = 4
    spacing_s = Uniform()
    spacing_c = Uniform()
    mirror = false
    symmetric = false

    # reference parameters
    cref = c
    bref = b
    Sref = S
    rref = [0.0, 0.0, 0.0]
    Vinf = 1.0
    ref = Reference(Sref, cref, bref, rref, Vinf)

    # freestream parameters
    alpha = 5.0*pi/180
    beta = 0.0
    Omega = [0.0; 0.0; 0.0]
    fs = Freestream(Vinf, alpha, beta, Omega)

    # create vortex rings
    grid, surface = wing_to_surface_panels(xle, yle, zle, chord, theta, phi, ns, nc;
        mirror=mirror, fc=fc, spacing_s=spacing_s, spacing_c=spacing_c)

    # create vector containing surfaces
    surfaces = [surface]

    # run analysis
    system, surface_history, property_history, wake_history =
        unsteady_analysis(surfaces, ref, fs, dt; symmetric, wake_finite_core = false, nwake=50)

    # extract forces at each time step
    CF, CM = body_forces_history(system, surface_history,
        property_history; frame=Wind())

    write_vtk("acceleration-AR4", surface_history, property_history,
              wake_history, dt; symmetric=false)
end

end # module
```